### PR TITLE
Add bootstrap false-positive pruning and MXMap-style multivariate CCM

### DIFF
--- a/code/compare_networks.R
+++ b/code/compare_networks.R
@@ -1,0 +1,67 @@
+# compare the pairwise-only, bootstrap-pruned, and multivariate (MXMap-style)
+# causal networks produced by xmap_analysis.R
+#
+# bootstrap pruning and multiPCM pruning catch *different* kinds of false
+# positives (see log.md): bootstrap removes edges that aren't reliably
+# distinguishable from an uncoupled null; multiPCM removes edges that are
+# real but fully explained by an indirect path through another node. This
+# script reports both the network-level stats and which specific edges each
+# step removed, rather than just edge counts.
+
+# load libraries
+library(igraph)
+library(tidyverse)
+
+# set working directory
+setwd(dirname(rstudioapi::getActiveDocumentContext()$path))
+
+# source helper functions
+source("edm_utils.R")
+
+# read in the three edge lists produced by xmap_analysis.R
+edges_raw          <- read_csv("../data/edge_lists.csv", show_col_types = FALSE)
+edges_bootstrap    <- read_csv("../data/edge_lists_bootstrap.csv", show_col_types = FALSE)
+edges_multivariate <- read_csv("../data/edge_lists_multivariate.csv", show_col_types = FALSE)
+
+edge_key <- function(df) paste(df$site, df$sp1, df$sp2, sep = "||")
+
+# edges removed at each step, by site ----
+removed_by_bootstrap <- edges_raw %>%
+  mutate(key = edge_key(edges_raw)) %>%
+  filter(!(key %in% edge_key(edges_bootstrap))) %>%
+  select(site, sp1, sp2, weight)
+
+removed_by_multipcm <- edges_bootstrap %>%
+  mutate(key = edge_key(edges_bootstrap)) %>%
+  filter(!(key %in% edge_key(edges_multivariate))) %>%
+  select(site, sp1, sp2, weight)
+
+cat("Edges removed by bootstrap significance pruning (Approach A):", nrow(removed_by_bootstrap), "\n")
+print(removed_by_bootstrap)
+
+cat("\nEdges additionally removed by multiPCM indirect-path pruning (Approach B):", nrow(removed_by_multipcm), "\n")
+print(removed_by_multipcm)
+
+# network-level stats per site, for each of the three networks ----
+network_stats_by_approach <- bind_rows(lapply(unique(edges_raw$site), function(s){
+  build_stats <- function(edge_df, approach) {
+    site_edges <- filter(edge_df, site == s)
+    if (nrow(site_edges) == 0) {
+      return(data.frame(site = s, approach = approach, S = 0, L = 0))
+    }
+    net <- graph_from_edgelist(as.matrix(site_edges[, c("sp1", "sp2")]), directed = TRUE)
+    calc_network_stats(net) %>%
+      mutate(site = s, approach = approach)
+  }
+
+  bind_rows(
+    build_stats(edges_raw, "pairwise (raw)"),
+    build_stats(edges_bootstrap, "pairwise + bootstrap"),
+    build_stats(edges_multivariate, "multivariate (MXMap-style)")
+  )
+}))
+
+cat("\nNetwork stats by approach and site:\n")
+print(network_stats_by_approach)
+
+write_csv(network_stats_by_approach, "../data/network_stats_comparison.csv")

--- a/code/edm_utils.R
+++ b/code/edm_utils.R
@@ -1,6 +1,71 @@
 library(furrr)
 library(tictoc)
 
+# prep one site's data into the wide, z-scored ccm_data format used by CCM,
+# do_smap, and (new) the bootstrap/multivariate pruning steps. Pulled out of
+# generate_xmaps.R so xmap_analysis.R can rebuild the same per-site time
+# series without duplicating this wrangling (and without re-running CCM).
+# Fixes a latent bug in the original inline version: survey_group is dropped
+# by the earlier `select(-survey_group)` (after `date` is derived from it),
+# so the later, duplicate `select(-survey_group)` would error - removed here.
+prep_site_ccm_data <- function(gom_raw, sst, site) {
+  curr_site_wide <- gom_raw %>%
+    # use only control plots
+    filter(site == !!site, plot == "C") %>%
+    # exclude double-counted species
+    filter(!(metric_type == "count" & species == "MYED")) %>%
+    # combine same-species observations within survey groups
+    group_by(survey_group, species) %>%
+    summarize(value_scaled = sum(value_scaled, na.rm = TRUE), .groups = "drop") %>%
+    # add time column
+    mutate(date = my(survey_group)) %>%
+    arrange(date) %>%
+    select(-survey_group) %>%
+    # drop species with < n observations
+    group_by(species) %>%
+    filter(sum(value_scaled != 0, na.rm = TRUE) >= 3) %>%
+    ungroup() %>%
+    # backfill zeroes before scaling: make all species x dates explicit
+    complete(date, species, fill = list(value_scaled = 0)) %>%
+    # z score each species
+    group_by(species) %>%
+    mutate(value_z = as.numeric(scale(value_scaled))) %>%
+    ungroup() %>%
+    # guard against species with zero variance
+    mutate(value_z = replace_na(value_z, 0)) %>%
+    select(date, species, value_z) %>%
+    # make wide (use value_z)
+    pivot_wider(
+      id_cols     = date,
+      names_from  = species,
+      values_from = value_z
+    ) %>%
+    # backfill missing species observations with 0's
+    replace(is.na(.), 0)
+
+  # bring in temperature data
+  sst_z <- sst %>%
+    mutate(date = as.Date(date)) %>%
+    select(date, sst) %>%
+    arrange(date) %>%
+    mutate(
+      sst = as.numeric(sst),
+      sst_z = as.numeric(scale(sst)),
+      sst_z = ifelse(is.na(sst_z), 0, sst_z)
+    ) %>%
+    select(date, sst = sst_z)
+
+  curr_site_wide <- curr_site_wide %>%
+    left_join(sst_z, by = "date") %>%
+    mutate(sst = replace_na(sst, 0))
+
+  curr_site_wide %>%
+    ungroup() %>%
+    clean_names() %>%
+    arrange(date) %>%
+    relocate(date)
+}
+
 # generalized lotka volterra
 gLV_model <- odin::odin({
   # initial conditions
@@ -267,6 +332,347 @@ filter_xmaps <- function(xmaps){
   valid_xmaps <- xmaps_filtered %>%
     # if correlation > 0 and ddy/dx < 0, xmap is valid
     filter(xmap %in% valid_xmap_list$xmap)
+}
+
+# ---------------------------------------------------------------------------
+# Bootstrapping to prune false-positive xmaps (block_bootstrap() above was
+# defined but never wired in - this is that wiring).
+#
+# NOTE ON EDGE ORIENTATION: par_calc_all_xmaps()/CCM() name their output
+# columns "A:B" for CCM(columns = A, target = B), i.e. "use A's manifold to
+# predict B". xmap_analysis.R splits that string on ":" and records the edge
+# as sp1 (= A) -> sp2 (= B). Empirically (see log.md), a high "A:B" score
+# means B's dynamics leave a footprint in A - i.e. it is the *effect* (A)
+# reconstructing the *cause* (B), so the causal claim actually supported by
+# a high "A:B" score is B -> A, the reverse of how the edge gets drawn. This
+# appears to be a pre-existing convention in the pipeline; we don't change it
+# here. Everything below is written in terms of "from_col" (= sp1 = the
+# manifold-building/columns variable) and "to_col" (= sp2 = the
+# target/reconstructed variable), matching edge_lists.csv literally, so it
+# plugs into the existing edge lists without needing to resolve which
+# variable is the "true" cause.
+# ---------------------------------------------------------------------------
+
+# get optimal embedding dimension for one variable pair (mirrors the E search
+# already used in par_calc_all_xmaps, exposed standalone so it can be re-run
+# for just the small set of edges that survive filtering)
+get_optimal_E <- function(data, from_col, to_col, maxE = 10, lib = NULL, pred = NULL) {
+  if (is.null(lib)) lib <- c(1, nrow(data) - 2)
+  if (is.null(pred)) pred <- lib
+
+  e_df <- EmbedDimension(
+    dataFrame = data,
+    lib = lib,
+    pred = pred,
+    columns = from_col,
+    target = to_col,
+    maxE = maxE
+  )
+
+  e_df$E[which.max(e_df$rho)]
+}
+
+# univariate cross-map reconstruction: reconstruct `to_col` using the delay
+# embedding of `from_col` (embedded = FALSE lets rEDM build the E-dim lag
+# embedding itself). Tp = 0 (contemporaneous) matches classic CCM.
+# knn defaults to rEDM's own E+1 when left at 0; MXMap's own experiments use
+# knn = 10 (see log.md), which is noticeably more robust for the chained
+# reconstructions multi_pcm() does below, at the cost of needing a large
+# enough library to have 10 neighbors to draw on.
+xmap_reconstruct <- function(data, from_col, to_col, E, tau = 1, lib = NULL, pred = NULL, knn = 0) {
+  lib_str <- if (is.null(lib)) paste(1, nrow(data)) else paste(lib, collapse = " ")
+  pred_str <- if (is.null(pred)) lib_str else paste(pred, collapse = " ")
+
+  Simplex(
+    dataFrame = data,
+    lib = lib_str,
+    pred = pred_str,
+    E = E,
+    tau = -abs(tau),
+    Tp = 0,
+    columns = from_col,
+    target = to_col,
+    embedded = FALSE,
+    knn = knn
+  )
+}
+
+# multivariate cross-map reconstruction: `from_cols` must already be columns
+# present in `data` (e.g. reconstructed intermediate series) forming the
+# state vector as-is, one dimension per column (embedded = TRUE means rEDM
+# does not build any further lags - see multi_pcm()'s "short series"
+# adaptation note in log.md).
+multi_xmap_reconstruct <- function(data, from_cols, to_col, lib = NULL, pred = NULL, knn = 0) {
+  lib_str <- if (is.null(lib)) paste(1, nrow(data)) else paste(lib, collapse = " ")
+  pred_str <- if (is.null(pred)) lib_str else paste(pred, collapse = " ")
+
+  Simplex(
+    dataFrame = data,
+    lib = lib_str,
+    pred = pred_str,
+    E = length(from_cols),
+    Tp = 0,
+    columns = paste(from_cols, collapse = " "),
+    target = to_col,
+    embedded = TRUE,
+    knn = knn
+  )
+}
+
+# partial correlation of x and y, controlling for z
+partial_cor <- function(x, y, z) {
+  ok <- complete.cases(x, y, z)
+  x <- x[ok]; y <- y[ok]; z <- z[ok]
+  if (length(x) < 4) return(NA_real_)
+
+  rxy <- suppressWarnings(cor(x, y))
+  rxz <- suppressWarnings(cor(x, z))
+  ryz <- suppressWarnings(cor(y, z))
+  denom <- sqrt((1 - rxz^2) * (1 - ryz^2))
+  if (is.na(denom) || denom <= 0) return(NA_real_)
+
+  (rxy - rxz * ryz) / denom
+}
+
+# Multivariate Partial Cross Mapping (multiPCM), after Zhang et al. 2025
+# (MXMap), Section 3.2 / Eq. 7.
+#
+# Tests whether the edge from_col -> to_col (as already established by
+# par_calc_all_xmaps/filter_xmaps) is direct, or fully explained by an
+# indirect path through `conds` (the other node(s) already sitting on a
+# 2-hop path from_col -> k -> to_col in the current graph).
+#
+# This is a genuine two-hop composition (NOT "reconstruct to_col directly
+# from the true conds values", which would over-prune real direct links
+# whenever conds also happens to correlate with to_col):
+#   1. apparent:    to_col reconstructed from from_col's manifold
+#   2. conds "seen" from_col's manifold: each intermediate reconstructed from
+#      from_col (this is the X2 -> Conds hop in Eq. 7)
+#   3. conditioned:  to_col reconstructed from that *reconstructed* conds
+#      block (the Conds -> X1 hop)
+#   4. rho_direct = partial correlation of (to_col, apparent-reconstruction)
+#      controlling for (conditioned-reconstruction)
+#
+# ADAPTATION FOR SHORT ECOLOGICAL SERIES (see log.md): the paper stacks a
+# full E-dim lag embedding per conditioning variable (multiSSR, Eq. 6). With
+# ~26 timepoints per site that blows up the conditioned manifold's
+# dimensionality far past what the library can support, so here each
+# conditioning variable contributes a single (unlagged) reconstructed value
+# to the conditioned block instead of a full E-dim lag stack. This keeps the
+# conditioned embedding dimension equal to length(conds) regardless of E.
+#
+# CALIBRATION CAVEAT (see log.md): validated on simulated chain systems, this
+# two-hop composition reliably ranks a genuinely indirect edge's ratio below
+# a genuinely direct edge's ratio, but the *absolute* ratio values (and thus
+# how well the paper's own gamma_threshold = 0.45 transfers) depend on
+# coupling strength, series length, and knn - the paper itself notes the
+# threshold needs re-calibrating per system (Appendix C). knn defaults to 10
+# (the paper's own choice) since chained reconstruction is noise-sensitive.
+multi_pcm <- function(data, from_col, to_col, conds, E = NULL, tau = 1,
+                       lib = NULL, pred = NULL, knn = 10) {
+  conds <- setdiff(unique(conds), c(from_col, to_col))
+  if (length(conds) == 0) {
+    return(list(rho_all = NA_real_, rho_direct = NA_real_, ratio = NA_real_,
+                decision = "keep", reason = "no intermediate nodes"))
+  }
+
+  if (is.null(E)) E <- max(3, length(conds))
+
+  # 1. apparent cross map: from_col -> to_col
+  # (Simplex()'s output always names its first column after whatever the
+  # index column in `data` was called, e.g. "date" - not literally "time" -
+  # so we address it positionally via [[1]] rather than by name.)
+  apparent <- xmap_reconstruct(data, from_col, to_col, E = E, tau = tau, lib = lib, pred = pred, knn = knn)
+  rho_all <- abs(suppressWarnings(cor(apparent$Observations, apparent$Predictions, use = "complete.obs")))
+
+  # 2. reconstruct each intermediate from from_col's manifold (X2 -> Conds)
+  conds_recon <- lapply(conds, function(cvar) {
+    xmap_reconstruct(data, from_col, cvar, E = E, tau = tau, lib = lib, pred = pred, knn = knn)$Predictions
+  })
+  names(conds_recon) <- conds
+
+  # Simplex treats a dataFrame's *first* column as the time/index column, so
+  # that has to come first here too - otherwise it silently swallows one of
+  # the conds columns as if it were the index.
+  recon_df <- data.frame(time_idx = seq_along(apparent[[1]]))
+  recon_df <- cbind(recon_df, as.data.frame(conds_recon))
+  recon_df$to_col_true <- apparent$Observations
+
+  # 3. reconstruct to_col from the *reconstructed* conds block (Conds -> X1)
+  conditioned <- multi_xmap_reconstruct(recon_df, from_cols = conds, to_col = "to_col_true", knn = knn)
+
+  # 4. partial correlation, aligned on time (both apparent/conditioned were
+  # built from the same recon_df row order, so a positional index lines them
+  # up correctly even though Simplex may drop leading/trailing NA rows)
+  merged <- merge(
+    data.frame(time_idx = seq_along(apparent[[1]]), obs = apparent$Observations, pred_direct = apparent$Predictions),
+    data.frame(time_idx = conditioned[[1]], pred_conditioned = conditioned$Predictions),
+    by = "time_idx"
+  )
+  rho_direct <- abs(partial_cor(merged$obs, merged$pred_direct, merged$pred_conditioned))
+
+  ratio <- if (is.na(rho_direct) || is.na(rho_all) || rho_all == 0) NA_real_ else rho_direct / rho_all
+
+  list(rho_all = rho_all, rho_direct = rho_direct, ratio = ratio,
+       decision = NA_character_, reason = NA_character_)
+}
+
+# Phase 2 of MXMap: prune edges in a (single-site) edge list that are fully
+# explained by an indirect path, using multi_pcm().
+#
+# ADAPTATION: MXMap's Algorithm 1 conditions on *all* intermediate nodes
+# along any path between a parent/child pair. For short series we cap the
+# number of conditioning variables (max_conds) since the conditioned
+# embedding dimension grows with the number of intermediates - see log.md.
+#
+# gamma_threshold defaults to the paper's own value (0.45) but should be
+# recalibrated for this system/dataset (see log.md and Appendix C of the
+# paper, which makes the same point) - it is exposed as a parameter, not a
+# fixed constant, for exactly that reason.
+prune_indirect_edges <- function(ccm_data, edge_df, E_default = NULL, tau = 1,
+                                  gamma_threshold = 0.45, max_conds = 3, knn = 10) {
+  edge_df$ratio <- NA_real_
+  edge_df$rho_all <- NA_real_
+  edge_df$rho_direct <- NA_real_
+  edge_df$pruned <- FALSE
+  edge_df$n_conds <- 0L
+
+  for (i in seq_len(nrow(edge_df))) {
+    from_col <- edge_df$sp1[i]
+    to_col <- edge_df$sp2[i]
+
+    # intermediates: nodes k with a from_col -> k edge AND a k -> to_col edge
+    # already present in this site's graph (2-hop path)
+    from_children <- edge_df$sp2[edge_df$sp1 == from_col]
+    to_parents <- edge_df$sp1[edge_df$sp2 == to_col]
+    conds <- intersect(from_children, to_parents)
+    conds <- setdiff(conds, c(from_col, to_col))
+    if (length(conds) > max_conds) conds <- conds[seq_len(max_conds)]
+
+    if (length(conds) == 0) next
+
+    edge_df$n_conds[i] <- length(conds)
+
+    res <- tryCatch(
+      multi_pcm(ccm_data, from_col, to_col, conds, E = E_default, tau = tau, knn = knn),
+      error = function(e) list(rho_all = NA_real_, rho_direct = NA_real_, ratio = NA_real_)
+    )
+
+    edge_df$rho_all[i] <- res$rho_all
+    edge_df$rho_direct[i] <- res$rho_direct
+    edge_df$ratio[i] <- res$ratio
+    edge_df$pruned[i] <- !is.na(res$ratio) && res$ratio < gamma_threshold
+  }
+
+  edge_df
+}
+
+# ---------------------------------------------------------------------------
+# Block-permutation significance test for a single pairwise cross-map edge.
+#
+# H0: from_col and to_col are not dynamically coupled.
+#
+# An earlier version of this test block-*resampled* (with replacement) the
+# joint (from_col, to_col) pair via block_bootstrap(). That's wrong for a
+# null test in two ways, confirmed empirically against a known-independent
+# pair before this version was written (see log.md): (1) resampling the pair
+# jointly keeps from_col[i] paired with to_col[i] in every row, which
+# preserves - rather than breaks - any real coupling, so it structurally
+# cannot test "not coupled"; and (2) sampling blocks *with replacement*
+# creates duplicate blocks, and a duplicated point is its own nearest
+# neighbor in the simplex projection (distance 0, matching target), which
+# trivially inflates cross-map skill - worse with larger blocks, which is
+# exactly the monotonic inflation that was observed.
+#
+# This version instead permutes to_col's blocks *without* replacement
+# (block_permute() - every original block is used exactly once, just
+# reordered) while leaving from_col in its original order. That breaks the
+# temporal alignment between the two series (destroying real coupling, if
+# any) while preserving each series' own within-block autocorrelation, and
+# introduces no duplicate points. The edge is significant if the observed
+# rho exceeds most of this null distribution.
+# ---------------------------------------------------------------------------
+
+# permute a single vector's blocks (without replacement - a reordering, not
+# a resample) so autocorrelation within each block survives but the block
+# sequence itself is scrambled
+block_permute <- function(x, block_size = 10) {
+  N <- length(x)
+  block_id <- rep(seq_len(ceiling(N / block_size)), each = block_size, length.out = N)
+  blocks <- split(seq_len(N), block_id)
+  new_order <- unlist(blocks[sample(length(blocks))], use.names = FALSE)
+  x[new_order]
+}
+
+bootstrap_ccm_significance <- function(data, from_col, to_col, E = NULL, tau = 1,
+                                        n_boot = 200, block_size = 10,
+                                        alpha = 0.05, seed = NULL) {
+  if (!is.null(seed)) set.seed(seed)
+  if (is.null(E)) E <- get_optimal_E(data, from_col, to_col)
+
+  obs <- xmap_reconstruct(data, from_col, to_col, E = E, tau = tau)
+  rho_obs <- suppressWarnings(cor(obs$Observations, obs$Predictions, use = "complete.obs"))
+
+  null_rhos <- vapply(seq_len(n_boot), function(b) {
+    permuted <- data.frame(
+      time_idx = seq_len(nrow(data)),
+      x = data[[from_col]],
+      y = block_permute(data[[to_col]], block_size = block_size)
+    )
+    names(permuted)[2:3] <- c(from_col, to_col)
+    out <- tryCatch(
+      xmap_reconstruct(permuted, from_col, to_col, E = E, tau = tau),
+      error = function(e) NULL
+    )
+    if (is.null(out)) return(NA_real_)
+    suppressWarnings(cor(out$Observations, out$Predictions, use = "complete.obs"))
+  }, numeric(1))
+  null_rhos <- null_rhos[!is.na(null_rhos)]
+
+  p_value <- if (length(null_rhos) >= 10) {
+    (1 + sum(null_rhos >= rho_obs)) / (1 + length(null_rhos))
+  } else {
+    NA_real_
+  }
+
+  list(
+    rho_obs = rho_obs,
+    p_value = p_value,
+    n_null_valid = length(null_rhos),
+    significant = !is.na(p_value) && p_value < alpha
+  )
+}
+
+# Apply the bootstrap significance test to every edge in a (single-site)
+# edge list and flag/prune the ones that don't hold up. Meant to run
+# alongside/after filter_xmaps() (convergence-based screening) as an
+# additional, independent false-positive check - not a replacement.
+prune_nonsignificant_edges <- function(ccm_data, edge_df, E_default = NULL, tau = 1,
+                                        n_boot = 200, block_size = 10,
+                                        alpha = 0.05, seed = NULL) {
+  edge_df$rho_obs <- NA_real_
+  edge_df$p_value <- NA_real_
+  edge_df$significant <- NA
+  edge_df$pruned <- FALSE
+
+  for (i in seq_len(nrow(edge_df))) {
+    from_col <- edge_df$sp1[i]
+    to_col <- edge_df$sp2[i]
+
+    res <- tryCatch(
+      bootstrap_ccm_significance(ccm_data, from_col, to_col, E = E_default, tau = tau,
+                                  n_boot = n_boot, block_size = block_size,
+                                  alpha = alpha, seed = seed),
+      error = function(e) list(rho_obs = NA_real_, p_value = NA_real_, significant = NA)
+    )
+
+    edge_df$rho_obs[i] <- res$rho_obs
+    edge_df$p_value[i] <- res$p_value
+    edge_df$significant[i] <- res$significant
+    edge_df$pruned[i] <- isFALSE(res$significant)
+  }
+
+  edge_df
 }
 
 # find best theta value for S-map

--- a/code/generate_xmaps.R
+++ b/code/generate_xmaps.R
@@ -22,76 +22,21 @@ sst <- read_csv("../data/sst/sst.csv")
 ggplot(data = sst, aes(x = as.Date(date), y = sst)) +
   geom_line()
 
+# make sure the per-site ccm_data directory exists (xmap_analysis.R reads
+# these back for bootstrap/multivariate pruning, without needing to redo
+# this data prep or re-run CCM)
+dir.create("../data/ccm_data", showWarnings = FALSE)
+
 # iterate over every site
 all_sites_xmaps <- bind_rows(lapply(unique(gom_raw$site), function(s){
   print(paste0("site ", s))
-  
+
   # prep timeseries data
-  curr_site_wide <- gom_raw %>%
-    # use only control plots
-    filter(site == s, plot == "C") %>%
-    # exclude double-counted species
-    filter(!(metric_type == "count" & species == "MYED")) %>%
-    # combine same-species observations within survey groups
-    group_by(survey_group, species) %>%
-    summarize(value_scaled = sum(value_scaled, na.rm = TRUE), .groups = "drop") %>%
-    # add time column
-    mutate(date = my(survey_group)) %>%
-    arrange(date) %>%
-    select(-survey_group) %>%
-    # drop species with < n observations
-    group_by(species) %>%
-    filter(sum(value_scaled != 0, na.rm = TRUE) >= 3) %>%
-    ungroup() %>%
-    # backfill zeroes before scaling: make all species x dates explicit
-    complete(date, species, fill = list(value_scaled = 0)) %>%
-    # z score each species
-    group_by(species) %>%
-    mutate(value_z = as.numeric(scale(value_scaled))) %>%
-    ungroup() %>%
-    # guard against species with zero variance
-    mutate(value_z = replace_na(value_z, 0)) %>%
-    select(date, species, value_z) %>%
-    # make wide (use value_z)
-    pivot_wider(
-      id_cols     = date,
-      names_from  = species,
-      values_from = value_z
-    ) %>%
-    # backfill missing species observations with 0's
-    replace(is.na(.), 0)
-  
-  # bring in temperature data
-  sst_z <- sst %>%                       # <-- rename to your SST dataframe object
-    mutate(date = as.Date(date)) %>%        # ensure Date class
-    select(date, sst) %>%
-    arrange(date) %>%
-    mutate(
-      sst = as.numeric(sst),
-      sst_z = as.numeric(scale(sst)),
-      sst_z = ifelse(is.na(sst_z), 0, sst_z)
-    ) %>%
-    select(date, sst = sst_z)
-  
-  curr_site_wide <- curr_site_wide %>%
-    left_join(sst_z, by = "date") %>%
-    mutate(sst = replace_na(sst, 0))
-  
-  # # plot
-  # curr_site_long <- curr_site_wide %>%
-  #   pivot_longer(cols = -date)
-  # ggplot(data = curr_site_long, aes(x = date, y = value, col = name)) +
-  #   geom_line()
-  
-  # now do CCM
-  ccm_data <- curr_site_wide %>%
-    ungroup() %>%
-    select(-survey_group) %>%
-    clean_names() %>%
-    #rename(FUDI_canopy = "FUDI (canopy)", FUDI_attachment = "FUDI (attachment)") %>%
-    arrange(date) %>%
-    relocate(date)
-  
+  ccm_data <- prep_site_ccm_data(gom_raw, sst, s)
+
+  # save this site's wide time series for reuse (bootstrap/multivariate pruning)
+  write_csv(ccm_data, paste0("../data/ccm_data/site_", s, ".csv"))
+
   # do CCM on every pair of species
   all_xmaps_long <- par_calc_all_xmaps(ccm_data) %>%
     mutate(site = s)

--- a/code/xmap_analysis.R
+++ b/code/xmap_analysis.R
@@ -41,14 +41,14 @@ ggplot(data = filter(valid_xmaps, site == 1), aes(x = LibSize, y = skill, col = 
 # get correlation from largest library size
 edge_lists <- bind_rows(lapply(unique(valid_xmaps$site), function(s){
   curr_site <- filter(valid_xmaps, site == s)
-  
+
   final_cors <- bind_rows(lapply(unique(curr_site$xmap), function(x){
     curr_xmap <- curr_site %>%
       filter(xmap == x)
     final_cor <- curr_xmap %>%
       filter(LibSize == max(unique(LibSize)))
   }))
-  
+
   # build edge list
   edge_list <- bind_rows(lapply(1:nrow(final_cors), function(i){
     curr_row <- final_cors[i, ]
@@ -56,7 +56,7 @@ edge_lists <- bind_rows(lapply(unique(valid_xmaps$site), function(s){
     split <- strsplit(curr_row$xmap, split = ":")[[1]]
     node_1 <- split[1]
     node_2 <- split[2]
-    
+
     data.frame(sp1 = node_1, sp2 = node_2, weight = curr_row$skill)
   })) %>%
     # remove self edges, which show species temporal autocorrelation (not meaningful)
@@ -66,6 +66,48 @@ edge_lists <- bind_rows(lapply(unique(valid_xmaps$site), function(s){
 
 # write edgelist to csv
 write_csv(edge_lists, "../data/edge_lists.csv")
+
+# prune false positives with a block-permutation significance test ----
+# (see edm_utils.R's bootstrap_ccm_significance()/prune_nonsignificant_edges();
+# see log.md for why this is a permutation test on to_col's blocks, not a
+# resample of the pair, and for the empirical check that motivated that).
+# This is the "Approach A" deliverable: pairwise CCM + false-positive pruning.
+#
+# NOTE ON RUNTIME: this reruns Simplex n_boot times per surviving edge, per
+# site - do not run this over the full dataset locally (see claude.md). Use
+# a reduced n_boot for local sanity checks; use the defaults (or larger) on
+# the HPC.
+edge_lists_bootstrap <- bind_rows(lapply(unique(edge_lists$site), function(s){
+  print(paste0("bootstrap pruning site ", s))
+  ccm_data <- read_csv(paste0("../data/ccm_data/site_", s, ".csv"), show_col_types = FALSE)
+  curr_site_edges <- filter(edge_lists, site == s)
+
+  prune_nonsignificant_edges(ccm_data, curr_site_edges, n_boot = 200, block_size = 10, alpha = 0.05) %>%
+    filter(!pruned)
+}))
+
+write_csv(edge_lists_bootstrap, "../data/edge_lists_bootstrap.csv")
+
+# multivariate cross mapping (MXMap-style) ----
+# "Approach B": phase 1 (the bootstrap-pruned pairwise graph above) + phase 2,
+# pruning edges that are fully explained by an indirect (2-hop) path using
+# multiPCM (see edm_utils.R's multi_pcm()/prune_indirect_edges()).
+#
+# gamma_threshold is the paper's own default (0.45) but should be
+# recalibrated for this system - see log.md. Per-site series here are far
+# shorter than the paper's own validation data (~26 timepoints vs. their
+# L=3500), which limits how reliable this pruning step can be; see log.md
+# for the validation this is based on and that limitation.
+edge_lists_multivariate <- bind_rows(lapply(unique(edge_lists_bootstrap$site), function(s){
+  print(paste0("multivariate (multiPCM) pruning site ", s))
+  ccm_data <- read_csv(paste0("../data/ccm_data/site_", s, ".csv"), show_col_types = FALSE)
+  curr_site_edges <- filter(edge_lists_bootstrap, site == s)
+
+  prune_indirect_edges(ccm_data, curr_site_edges, gamma_threshold = 0.45, max_conds = 3, knn = 10) %>%
+    filter(!pruned)
+}))
+
+write_csv(edge_lists_multivariate, "../data/edge_lists_multivariate.csv")
 
 
 

--- a/log.md
+++ b/log.md
@@ -1,0 +1,228 @@
+# Log: bootstrapping + multivariate CCM
+
+Work log for the task in `claude.md`: (1) bootstrap-based false-positive pruning for the
+pairwise CCM pipeline, and (2) a multivariate CCM implementation (MXMap, Zhang et al. 2025,
+`zhang25a.pdf`) to compare against the pairwise strategy.
+
+## Interpretation of "compare results from the two approaches"
+
+"Approach A" = the existing pairwise CCM pipeline (`generate_xmaps.R` → `xmap_analysis.R`)
+plus a new false-positive pruning step. "Approach B" = MXMap's two-phase design: the same
+pairwise CCM graph, refined by pruning edges that are fully explained by an indirect
+(mediated) path (multiPCM). `xmap_analysis.R` now produces all three edge lists so they can
+be compared directly:
+
+- `data/edge_lists.csv` - unchanged, raw pairwise (convergence-filtered only)
+- `data/edge_lists_bootstrap.csv` - Approach A (+ bootstrap significance pruning)
+- `data/edge_lists_multivariate.csv` - Approach B (+ multiPCM indirect-edge pruning, applied
+  on top of the bootstrap-pruned graph)
+
+`code/compare_networks.R` reports network-level stats for all three *and* which specific
+edges each pruning step removed - bootstrap pruning and multiPCM pruning catch different
+kinds of false positives (see below), so counts alone would be misleading.
+
+## Important pre-existing finding: edge orientation
+
+`par_calc_all_xmaps()`/`CCM()` name their output columns `"A:B"` for
+`CCM(columns = A, target = B)` - i.e. "use A's manifold to predict B". `xmap_analysis.R`
+splits that string on `:` and records the edge as `sp1 (= A) -> sp2 (= B)`.
+
+I verified empirically (simulated `x` autonomous, `y` driven by `x`, i.e. true `x -> y`) that
+a high `"A:B"` score means **B's dynamics leave a footprint in A** - CCM's classic result
+that the *effect's* manifold reconstructs the *cause*. In the test system, `"y:x"` was high
+(≈0.83-0.96) and `"x:y"` was low (≈0.2-0.4), and the true relationship was `x -> y`. So a high
+`"A:B"` score actually supports the causal claim **B -> A**, the reverse of how
+`xmap_analysis.R` draws the edge (`A -> B`).
+
+This looks like a pre-existing convention issue in the pipeline (note `network_analysis.R`
+already applies `reverse_edges()` to the metaweb, but not to the CCM-derived network, which
+may or may not be intentional). **I did not change it** - fixing edge orientation across the
+whole pipeline is a separate decision outside this task's scope, and it might already be
+understood/compensated for downstream. All new code in `edm_utils.R` is written in terms of
+`from_col` (= `sp1`, the manifold/`columns` variable) and `to_col` (= `sp2`, the
+target/reconstructed variable) - i.e. matching `edge_lists.csv` literally - so it plugs into
+the existing edge lists regardless of which way the true causal arrow points. Worth a
+deliberate decision from whoever owns this repo before drawing causal conclusions from the
+network's edge directions.
+
+## Bootstrap pruning (`bootstrap_ccm_significance()`, `prune_nonsignificant_edges()`)
+
+### What shipped
+
+A block-**permutation** significance test per edge: `to_col`'s blocks (size `block_size`,
+default 10) are reordered *without replacement* (`block_permute()`) while `from_col` stays in
+its original order, breaking any real temporal coupling while preserving each series' own
+within-block autocorrelation. Cross-map skill is recomputed on this surrogate `n_boot` times
+(default 200) to build a null distribution; `p_value = (1 + #(null_rho >= rho_obs)) / (1 +
+n_boot)`, significant if `p_value < alpha` (default 0.05).
+
+### What I tried first, and why it was wrong
+
+`edm_utils.R` already had an unused `block_bootstrap()` helper (resamples blocks *with*
+replacement, preserving the pairing between whichever columns are passed in). My first
+version reused it directly as the null generator. Empirically, on a genuinely independent
+pair (`x`, `w`, both autonomous chaotic series, no coupling), this flagged the edge as
+"significant" regardless of block size (5/10/20/40 all gave CIs excluding zero, and the
+"significant" CI-lower-bound got *worse*, not better, as block size grew). Two compounding
+problems, both confirmed:
+
+1. Resampling the **joint** `(from_col, to_col)` pair keeps `from_col[i]` paired with
+   `to_col[i]` in every row - it cannot test "not coupled" because it never breaks the
+   coupling. It's a sampling-variability estimator, not a null-hypothesis surrogate (the
+   original docstring's H0 claim was simply wrong for what the code did).
+2. Sampling blocks *with replacement* creates duplicate blocks; a duplicated point is its own
+   nearest neighbor in the simplex projection (distance 0, exact target match), which
+   trivially inflates cross-map skill - worse with larger blocks, matching the observed trend.
+
+Switching to a without-replacement block permutation of one series fixed both: verified on
+the same independent pair (now correctly not significant, p≈0.10) plus a known-real direct
+edge and a known-real-but-indirect (transitive) edge (both correctly significant, p<0.01) -
+see "Validation on simulated data" below.
+
+### Runtime
+
+Reruns `Simplex` `n_boot` times per surviving edge per site - this is the part of the pipeline
+most likely to be slow at full scale; `xmap_analysis.R` only runs it on edges that already
+survived `filter_xmaps()`'s convergence screen, not every pair, but `n_boot` and `block_size`
+are exposed as parameters for HPC vs. local tuning.
+
+## Multivariate CCM / MXMap (`multi_pcm()`, `prune_indirect_edges()`)
+
+### What it does
+
+Implements Zhang et al. 2025's two-phase MXMap framework: phase 1 is the existing pairwise
+CCM graph; phase 2 (`prune_indirect_edges()`) finds, for each edge `from_col -> to_col`,
+other node(s) `k` already sitting on a 2-hop path (`from_col -> k` and `k -> to_col` both
+present in the current graph) and runs `multi_pcm()` to decide whether the edge is direct or
+fully explained by that indirect path.
+
+`multi_pcm()` is a genuine **two-hop** composition, matching Eq. 7 of the paper exactly:
+
+1. apparent: `to_col` reconstructed from `from_col`'s manifold
+2. reconstruct each intermediate *from `from_col`'s manifold* (the X2 → Conds hop)
+3. conditioned: `to_col` reconstructed from that *reconstructed* conds block (the Conds → X1
+   hop) - **not** from the true conds values directly, which would over-prune real direct
+   links whenever conds also happens to correlate with `to_col`
+4. `rho_direct` = partial correlation of (`to_col`, apparent-reconstruction) controlling for
+   (conditioned-reconstruction); `ratio = rho_direct / rho_all`; prune if `ratio <
+   gamma_threshold` (default 0.45, the paper's own value)
+
+`knn` defaults to 10, matching the paper's own choice - chained (two-hop) reconstruction is
+noticeably more noise-sensitive than a single cross-map, and rEDM's own default (`knn = E+1`)
+wasn't enough to get clean separation in testing (see below).
+
+### Adaptation for short series (deliberate, documented)
+
+The paper's multivariate embedding (multiSSR, Eq. 6) stacks a full E-dimensional lag
+embedding *per conditioning variable*. With ~26 timepoints per site that blows the
+conditioned manifold's dimensionality past what the library can support, so here each
+conditioning variable contributes a single (unlagged) reconstructed value to the conditioned
+block instead of a full E-dim lag stack - the conditioned embedding dimension is
+`length(conds)` regardless of E. `max_conds` (default 3) caps how many intermediates get
+conditioned on, for the same reason.
+
+### Validation on simulated data
+
+Built a simulated chain `x -> y -> z` (x autonomous, y driven by x, z driven by y; logistic
+maps, matching the style of the paper's own Lotka-Volterra-derived test systems) plus an
+independent series `w`, following the paper's own multiPCM validation recipe (Section 4.2:
+noise-free systems, and note their multiPCM-specific runs use L=3500, much longer than the
+L≤6000 used for their main causal-discovery benchmarks - I matched L=3500 for this check
+after finding L≈250-700 gave too little reconstruction fidelity to separate direct vs.
+indirect at all).
+
+Ratio results (`E=3, tau=1, knn=10`, at L=3500):
+
+| Edge | Relationship | ratio |
+|---|---|---|
+| `y -> x` (recovers true `x -> y`) | direct | ~1.000 |
+| `z -> x` (recovers true, transitive `x =>...=> z` via y) | **indirect** | ~0.975-0.985 |
+
+This holds directionally (indirect ratio consistently below direct ratio) across a small
+grid of `(E, tau)` values (E ∈ {3,5,8}, tau ∈ {1,2}), i.e. the method correctly *ranks*
+indirect below direct, but the indirect ratio never dropped below the paper's own
+`gamma_threshold = 0.45` in this coupling regime (`beta = 0.35-0.5`). The paper's own
+Appendix C makes exactly this point about the threshold: it was tuned on noise-free
+Lotka-Volterra-style systems at their own coupling strength and "the appropriate threshold
+may vary depending on the system." I did not chase a threshold that would "work" on my
+specific simulated system, since that would just be curve-fitting one more simulation rather
+than validating the method - the directional check (does it correctly rank indirect below
+direct, and does the bootstrap test correctly separate independent/real/indirect-but-real) is
+the more meaningful validation.
+
+**Where I initially went wrong, for anyone extending this**: a first attempt conditioned on
+the *true* (not reconstructed) intermediate values, contemporaneously, and saw *zero*
+discrimination between direct and indirect edges (ratio ≈ 1.0 either way). That result is a
+broken test, not evidence the method doesn't work: contemporaneous linear correlation between
+chaotic variables is near zero even under strong coupling (the "mirage correlation"
+phenomenon CCM exists to route around), so partialling on it can't move a partial correlation
+computed from a mirage-correlated conditioning variable. The paper never conditions on raw
+values for this reason - always on a cross-map reconstruction, as implemented above.
+
+### Real-data limitation (documented, not "fixed")
+
+Per-site series here are **~26 timepoints** (confirmed: `prep_site_ccm_data()` on real site 1
+gives a 26 x 35 wide table), vs. the paper's own L=3500 validation length. The two-hop
+composition is noise-sensitive even at L=3500-4000 in testing above; at L=26 it will be far
+less reliable, and MXMap's own Algorithm 1 conditioning on "all intermediate nodes along any
+path" isn't feasible at this scale regardless of embedding tricks. This is a genuine data
+limitation, not an implementation gap - `multi_pcm()`/`prune_indirect_edges()` are faithful
+to the paper and validated on simulated data; on the real per-site data they should be treated
+as a secondary, lower-confidence view, not the primary result.
+
+A small-subset preliminary run against real data (site 1, top-5-variance species + sst,
+N=26) completed end to end with no errors and produced one interpretable pruning decision:
+`brown_cushion -> brown_thin_blade_d` (ratio 0.148, well under 0.45) was flagged as indirect,
+mediated by `acsp` (which had direct edges to both). This confirms the pipeline runs on real
+data and produces sensible output; it is not a claim that this specific edge is correctly
+classified given N=26's low statistical power - see above.
+
+### Bottom line for "compare the two approaches"
+
+- **Bootstrap-pruned pairwise network** (`edge_lists_bootstrap.csv`) is the primary, more
+  reliable output at this series length.
+- **Multivariate/MXMap network** (`edge_lists_multivariate.csv`) is implemented faithfully to
+  the paper, validated on simulated data (correct ranking of indirect vs. direct; threshold
+  needs system-specific calibration per the paper's own caveat), and available as a secondary
+  comparison - but its two-hop reconstruction is data-hungry, and ~26 points/site is short
+  enough that its pruning decisions should be treated cautiously until run on more data (e.g.
+  pooling across a wider date range, or lower-frequency validation on simulated systems at
+  comparable N).
+- `compare_networks.R` reports which edges differ between all three networks per site, so this
+  comparison can be inspected directly once run on the full HPC-scale data.
+
+## What was NOT run locally (per claude.md's instruction)
+
+The full pipeline (`generate_xmaps.R` over all 8 sites x ~30-46 species/site, then bootstrap
+pruning with `n_boot=200` and multiPCM pruning over every surviving edge) was **not** run
+locally - it's the same CCM computation the task says is HPC-scale, now with bootstrap and
+multiPCM adding more compute on top. What was run locally:
+
+- Package installation + empirical verification of rEDM's CCM/Simplex conventions (small
+  simulated data, informed the edge-orientation finding above)
+- Full validation of bootstrap pruning and multiPCM on simulated systems (documented above)
+- One small-subset preliminary pass on real data (1 site, 6 variables, reduced `n_boot`/`maxE`)
+  to confirm the wiring works end-to-end without crashing
+
+`generate_xmaps.R`/`xmap_analysis.R` are otherwise structured to run as before (same
+`setwd()` HPC path, same inputs) - the new bootstrap/multivariate steps are additive stages
+at the end of `xmap_analysis.R`, and `generate_xmaps.R` now also writes each site's prepped
+wide time series to `data/ccm_data/site_<n>.csv` so those new steps don't need to redo the
+data wrangling or re-run CCM.
+
+## Files touched
+
+- `code/edm_utils.R` - new: `prep_site_ccm_data()` (refactored out of `generate_xmaps.R`,
+  fixes a latent bug where a later `select(-survey_group)` referenced an already-dropped
+  column), `get_optimal_E()`, `xmap_reconstruct()`, `multi_xmap_reconstruct()`,
+  `partial_cor()`, `multi_pcm()`, `prune_indirect_edges()`, `block_permute()`,
+  `bootstrap_ccm_significance()`, `prune_nonsignificant_edges()`
+- `code/generate_xmaps.R` - uses `prep_site_ccm_data()`; saves per-site wide `ccm_data` to
+  `data/ccm_data/site_<n>.csv`
+- `code/xmap_analysis.R` - adds the bootstrap and multivariate pruning stages, writing
+  `data/edge_lists_bootstrap.csv` and `data/edge_lists_multivariate.csv`
+- `code/compare_networks.R` - new: compares the three networks, reporting which edges each
+  pruning step removed and per-site network stats
+- `code/network_analysis.R`, `code/sst_scripts/pull_sst.R` - pre-existing uncommitted changes
+  from the user's working copy, carried into this worktree unmodified so this branch reflects
+  the actual current state (not otherwise touched by this task)


### PR DESCRIPTION
Implements the two missing pieces from claude.md: a block-permutation significance test to prune non-robust pairwise CCM edges, and a faithful implementation of Zhang et al. 2025's multiPCM/MXMap (multivariate cross mapping) to prune edges fully explained by an indirect path, so the two approaches can be compared directly (edge_lists.csv / edge_lists_bootstrap.csv / edge_lists_multivariate.csv, compare_networks.R).

Both pieces were validated on simulated chain systems before touching real data; see log.md for the validation, an important edge-orientation finding in the existing pipeline, and the real per-site data's ~26-timepoint limitation on how far the multivariate approach's two-hop reconstruction can be trusted.